### PR TITLE
Memberモデルのicon_urlを廃止する

### DIFF
--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -1,5 +1,4 @@
 class Member < ApplicationRecord
   validates :name, presence: true, length: { maximum: 32 }
-  validates :icon_url, presence: true, length: { maximum: 2083 }
   validates :discord_uid, uniqueness: true, presence: true, length: { maximum: 32 }
 end

--- a/db/migrate/20240907123411_remove_icon_url_column_from_members.rb
+++ b/db/migrate/20240907123411_remove_icon_url_column_from_members.rb
@@ -1,0 +1,5 @@
+class RemoveIconUrlColumnFromMembers < ActiveRecord::Migration[7.2]
+  def change
+    remove_column :members, :icon_url, :string, limit: 2083
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_08_31_142730) do
+ActiveRecord::Schema[7.2].define(version: 2024_09_07_123411) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -32,7 +32,6 @@ ActiveRecord::Schema[7.2].define(version: 2024_08_31_142730) do
 
   create_table "members", force: :cascade do |t|
     t.string "name", limit: 32, null: false
-    t.string "icon_url", limit: 2083, null: false
     t.string "discord_uid", limit: 32, null: false
     t.boolean "admin", default: false, null: false
     t.datetime "created_at", null: false


### PR DESCRIPTION
Discordのユーザがプロフィールアイコンを設定していない場合、auth_hashの中のimageもnilで帰ってくるみたいで、そうするとプロフィールアイコンを設定していないユーザはTobiraにログインできないという挙動になってしまう。

それは回避しなきゃいけないのと、Tobiraのアプリケーション内でMemberのアイコンをどうしても表示したいような場面もなさそうなので、思い切ってカラムを消しちゃうことにする。
