### PR TITLE
すでにDiscordサーバに参加している人もハンドリングしたい

### DIFF
--- a/app/models/invitation.rb
+++ b/app/models/invitation.rb
@@ -26,7 +26,7 @@ class Invitation < ApplicationRecord
     result = bot.invite(user_id: member.discord_uid, user_token: member.access_token)
     pp result
 
-    if result.status.in?([200, 204])
+    if result.status.in?([ 200, 204 ])
       pp bot.add_role(user_id: member.discord_uid, role_id: role.original_id)
 
       pp bot.send_message(

--- a/app/models/invitation.rb
+++ b/app/models/invitation.rb
@@ -26,7 +26,7 @@ class Invitation < ApplicationRecord
     result = bot.invite(user_id: member.discord_uid, user_token: member.access_token)
     pp result
 
-    if result.status == 201
+    if result.status.in?([200, 204])
       pp bot.add_role(user_id: member.discord_uid, role_id: role.original_id)
 
       pp bot.send_message(


### PR DESCRIPTION
サーバにユーザを招待するとき、

- まだサーバに入っていないユーザの場合 → ステータスコード201
- すでにサーバに入っているユーザの場合 → ステータスコード204

DiscordのWeb APIは、こういう応答になるってことを経験から理解した :memo:

ほんで、今までは201が返ってこなかったら「招待失敗！」だと思っていたからそういう処理にしていたんだけど、204のときも「Roleの付与」をやっておきたいので、実装を変えます :dizzy:
