### PR TITLE
招待に成功したときのコードは200じゃなくて201

### DIFF
--- a/app/models/invitation.rb
+++ b/app/models/invitation.rb
@@ -26,7 +26,7 @@ class Invitation < ApplicationRecord
     result = bot.invite(user_id: member.discord_uid, user_token: member.access_token)
     pp result
 
-    if result.status.in?([ 200, 204 ])
+    if result.status.in?([ 201, 204 ])
       pp bot.add_role(user_id: member.discord_uid, role_id: role.original_id)
 
       pp bot.send_message(


### PR DESCRIPTION
https://github.com/teacherteacher-jp/tobira/commit/f4df3bad14adc08ed29959d90bbea5da97330a0f がミスっていて、もともとハンドリングできていた201を取りこぼすようになっていました :bow: :sweat_drops:
