### PR TITLE
存在しない招待コードと使用済み招待コードでメッセージを出し分ける

### DIFF
--- a/app/controllers/invitations/acceptance_controller.rb
+++ b/app/controllers/invitations/acceptance_controller.rb
@@ -1,12 +1,15 @@
 class Invitations::AcceptanceController < ApplicationController
   def create
-    invitation = Invitation.not_used.find_by(code: params[:code].to_s.strip)
+    code = params[:code].to_s.strip
+    invitation = Invitation.find_by(code:)
 
-    if invitation
+    if invitation.nil?
+      redirect_to(root_path, notice: "招待コード「#{code}」は無効です。管理者に問い合わせてください。")
+    elsif invitation.used?
+      redirect_to(root_path, notice: "招待コード「#{code}」は使用済みです。Discordサーバーに参加できているかご確認ください。")
+    else
       invitation.used_by!(current_member)
       redirect_to(root_path, notice: "Discordサーバに招待しました！")
-    else
-      redirect_to(root_path, notice: "招待コードが無効のようです。管理者に問い合わせてください。")
     end
   end
 end

--- a/app/models/invitation.rb
+++ b/app/models/invitation.rb
@@ -52,6 +52,10 @@ class Invitation < ApplicationRecord
     end
   end
 
+  def used?
+    !used_at.nil?
+  end
+
   def guide_text
     <<~TEXT
       以下の手順に従って、Discordのコミュニティにご参加ください。


### PR DESCRIPTION
正しい招待コードを入力してDiscordサーバに招待されたが、そのことに気付かずに同じ招待コードを入力してしまうケースがあるようなので、表示メッセージを出し分けて「もう招待されているかもよ！見てみて！」を伝えていくことにする。
